### PR TITLE
Allow local frontend bypass cors to use APIs

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -172,6 +172,7 @@
     }
   },
   "redirects": {
+    "https://deno.land/x/cors/mod.ts": "https://deno.land/x/cors@v1.2.2/mod.ts",
     "https://deno.land/x/dotenv/mod.ts": "https://deno.land/x/dotenv@v3.2.2/mod.ts",
     "https://deno.land/x/mongo/mod.ts": "https://deno.land/x/mongo@v0.34.0/mod.ts",
     "https://deno.land/x/oak/mod.ts": "https://deno.land/x/oak@v17.1.4/mod.ts"
@@ -181,6 +182,14 @@
     "https://deno.land/std@0.224.0/dotenv/mod.ts": "0180eaeedaaf88647318811cdaa418cc64dc51fb08354f91f5f480d0a1309f7d",
     "https://deno.land/std@0.224.0/dotenv/parse.ts": "09977ff88dfd1f24f9973a338f0f91bbdb9307eb5ff6085446e7c423e4c7ba0c",
     "https://deno.land/std@0.224.0/dotenv/stringify.ts": "275da322c409170160440836342eaa7cf012a1d11a7e700d8ca4e7f2f8aa4615",
+    "https://deno.land/x/cors@v1.2.2/abcCors.ts": "cdf83a7eaa69a1bf3ab910d18b9422217902fac47601adcaf0afac5a61845d48",
+    "https://deno.land/x/cors@v1.2.2/attainCors.ts": "7d6aba0f942495cc31119604e0895c9bb8edd8f8baa7fe78e6c655bd0b4cbf59",
+    "https://deno.land/x/cors@v1.2.2/cors.ts": "0e2d9167e3685f9bcf48f565e312b6e1883fa458f7337e5ce7bc2e3b29767980",
+    "https://deno.land/x/cors@v1.2.2/mithCors.ts": "3a359d6e716e0410ede278ab54d875b293a2d66d838aaa7cfbf9ddc1e9e990d3",
+    "https://deno.land/x/cors@v1.2.2/mod.ts": "2b351913f56d77ad80cb3b8633d4539c9eeddb426dae79437ada0e6a9cb4f1a6",
+    "https://deno.land/x/cors@v1.2.2/oakCors.ts": "1348dc7673c61b85d2e80559a7b44f8e0246eaa6bcc6ec744fafe5d9b13b5c71",
+    "https://deno.land/x/cors@v1.2.2/opineCors.ts": "fb5790115c26b7061d84b8d6c17d258a1e241bcab75b0bc3ca1fdb2e57bc5072",
+    "https://deno.land/x/cors@v1.2.2/types.ts": "97546633ccc7f0df7a29bacba5d91dc6f61decdd1b65258300244dba905d34b8",
     "https://deno.land/x/dotenv@v3.2.2/mod.ts": "077b48773de9205266a0b44c3c3a3c3083449ed64bb0b6cc461b95720678d38e",
     "https://deno.land/x/dotenv@v3.2.2/util.ts": "693730877b13f8ead2b79b2aa31e2a0652862f7dc0c5f6d2f313f4d39c7b7670",
     "https://deno.land/x/mongo@v0.34.0/deps.ts": "c9ef5cc7fbe0d84c349590dca175abcf62988b1f87c2efda47e47d3f20fb741d",

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,10 @@
-export { oakCors } from "https://deno.land/x/cors/mod.ts";
-export { Application, Context, Router, Status } from 'https://deno.land/x/oak/mod.ts';
+export { oakCors } from 'https://deno.land/x/cors/mod.ts';
+export {
+  Application,
+  Context,
+  Router,
+  Status,
+} from 'https://deno.land/x/oak/mod.ts';
 export { ObjectId } from 'npm:mongodb@6.1.0';
 
 // Types

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,6 @@
-export { Context, Router, Status } from 'https://deno.land/x/oak/mod.ts';
-export type { RouterContext } from 'https://deno.land/x/oak/mod.ts';
+export { oakCors } from "https://deno.land/x/cors/mod.ts";
+export { Application, Context, Router, Status } from 'https://deno.land/x/oak/mod.ts';
 export { ObjectId } from 'npm:mongodb@6.1.0';
+
+// Types
+export type { RouterContext } from 'https://deno.land/x/oak/mod.ts';

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,11 @@
 import 'https://deno.land/std@0.224.0/dotenv/load.ts';
-import { Application } from 'https://deno.land/x/oak/mod.ts';
+import { Application, oakCors } from '../deps.ts';
 import './database/connect.ts';
 import router from './routes/index.ts';
 
 const app = new Application();
 
+app.use(oakCors({origin: "http://localhost:5173"}));    // Allow local frontend to bypass cors requirement
 app.use(router.routes());
 app.use(router.allowedMethods());
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import router from './routes/index.ts';
 
 const app = new Application();
 
-app.use(oakCors({origin: "http://localhost:5173"}));    // Allow local frontend to bypass cors requirement
+app.use(oakCors({ origin: 'http://localhost:5173' })); // Allow local frontend to bypass cors requirement
 app.use(router.routes());
 app.use(router.allowedMethods());
 


### PR DESCRIPTION
### ✨ What’s Changed?

Since currently both frontend and backend are two separate hosts with different port, cors rejects frontend's request as its under a local request. This PR allows frontend to bypass cors requirements.

### 📚 Related Issues

None

### ✅ Checklist

- [x] Lint passes (`deno lint`)
- [x] Code is formatted (`deno fmt`)
- [x] No type errors (`deno check main.ts(Replace main with current entry point should it change)`)
- [ ] Tests added or updated (if applicable)
