### PR TITLE
Allow local IP "127.0.0.1" bypass cors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,9 @@ import logRequest from './middleware/logRequest.ts';
 
 const app = new Application();
 
-app.use(oakCors({ origin: ['http://localhost:5173', 'http://127.0.0.1:5173'] })); // Allow local frontend to bypass cors requirement
+app.use(
+  oakCors({ origin: ['http://localhost:5173', 'http://127.0.0.1:5173'] }),
+); // Allow local frontend to bypass cors requirement
 app.use(logRequest);
 app.use(router.routes());
 app.use(router.allowedMethods());


### PR DESCRIPTION
### ✨ What’s Changed?

A really small PR, this is just to allow URL "http://127.0.0.1" able to bypass cors requirement, just like "http://localhost:5173" too.

### 📚 Related Issues

None

### ✅ Checklist

- [x] Lint passes (`deno lint`)
- [x] Code is formatted (`deno fmt`)
- [x] No type errors (`deno check main.ts(Replace main with current entry point should it change)`)
- [] Tests added or updated (if applicable)
